### PR TITLE
Add VTK 9.5.2 build workflow

### DIFF
--- a/.github/workflows/vtk-9.5.2.yml
+++ b/.github/workflows/vtk-9.5.2.yml
@@ -1,0 +1,25 @@
+name: VTK-9.5.2
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  shared:
+    uses: sanguinariojoe/vtk-builds/.github/workflows/builder.yml@main
+    with:
+      version_major: 9
+      version_minor: 5
+      version_patch: 2
+      shared: true
+    secrets: inherit
+  static:
+    uses: sanguinariojoe/vtk-builds/.github/workflows/builder.yml@main
+    with:
+      version_major: 9
+      version_minor: 5
+      version_patch: 2
+      shared: false
+    secrets: inherit


### PR DESCRIPTION
Add build workflow for VTK 9.5.2.

  ---

  **Note:** Remove the `pull_request` trigger before merging - it was added to test the build on CI.